### PR TITLE
Page/report

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="favicon.ico" />
     <title>Capstone 1</title>
-    <script defer src="main.js"></script>
+    <script defer src="/main.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Signup from "./components/Signup";
 import Home from "./pages/Home";
 import NotFound from "./components/NotFound";
 import { API_URL } from "./shared";
+import Report from "./pages/Report";
 
 const App = () => {
   const [user, setUser] = useState(null);
@@ -38,7 +39,7 @@ const App = () => {
         {},
         {
           withCredentials: true,
-        }
+        },
       );
       setUser(null);
     } catch (error) {
@@ -54,6 +55,7 @@ const App = () => {
           <Route path="/login" element={<Login setUser={setUser} />} />
           <Route path="/signup" element={<Signup setUser={setUser} />} />
           <Route exact path="/" element={<Home user={user} />} />
+          <Route path="/report/:id" element={<Report />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </div>

--- a/src/pages/Report.css
+++ b/src/pages/Report.css
@@ -1,0 +1,23 @@
+.report-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.report-id {
+    margin-bottom: 20px;
+}
+
+.report-list {
+    list-style-type: none;
+    padding: 0;
+}
+
+.report-list li {
+    margin-bottom: 10px;
+}
+
+#additional-comments {
+    padding: 5px;
+    width: 300px;
+}

--- a/src/pages/Report.css
+++ b/src/pages/Report.css
@@ -10,14 +10,25 @@
 
 .report-list {
     list-style-type: none;
-    padding: 0;
+    padding: 15px;
+    width: 95vw;
+    text-align: center;
+    border: 1px solid black;
+    background-color: lightgrey;
+    border-radius: 10px;
 }
 
 .report-list li {
-    margin-bottom: 10px;
+    margin: 10px;
 }
 
 #additional-comments {
     padding: 5px;
     width: 300px;
+    margin-top: 10px;
+}
+
+.errors {
+    color: red;
+    font-weight: bold;
 }

--- a/src/pages/Report.jsx
+++ b/src/pages/Report.jsx
@@ -3,21 +3,24 @@ import "./Report.css";
 import { useParams } from "react-router-dom";
 
 export default function Report() {
+  // There might need to be a GET request here to validate the echo id even exists initially, but probably not a priority for now
   const [formData, setFormData] = useState({
     reasons: {},
     "additional-comments": "",
   });
+  const [errors, setErrors] = useState({ reasons: "" });
   const params = useParams();
   const reportOptions = [
-    "Wrong Tags",
-    "Hate Speech",
-    "Personal Information",
-    "Threats of Violence/Terrorism",
+    "Wrong tags",
+    "Hate speech",
+    "Personal information",
+    "Threats of violence/Terrorism",
     "Breaks TOS",
     "Other",
   ];
 
   function handleChange(event) {
+    setErrors({ reasons: "" });
     const { name, value, checked } = event.target;
     if (name.startsWith("report-reason")) {
       setFormData({
@@ -37,6 +40,19 @@ export default function Report() {
 
   function submitReport(event) {
     event.preventDefault();
+    if (
+      !formData.reasons ||
+      Object.keys(formData.reasons).every((key) => !formData.reasons[key])
+    ) {
+      setErrors({ ...errors, reasons: "You must include at least 1 reason!" });
+      return;
+    } else if (formData.reasons["Other"] && !formData["additional-comments"]) {
+      setErrors({
+        ...errors,
+        other: 'Additional comments required for "Other"!',
+      });
+      return;
+    }
     const reportData = {
       echo_id: params.id,
       additionalComments: formData["additional-comments"],
@@ -45,6 +61,7 @@ export default function Report() {
       ),
     };
     console.log(reportData);
+    // Instead of logging should be a POST request here when ready
   }
 
   return (
@@ -67,9 +84,16 @@ export default function Report() {
       <textarea
         name="additional-comments"
         id="additional-comments"
-        placeholder="Additional Comments"
+        placeholder={
+          !formData.reasons["Other"]
+            ? "Additional Comments(optional)"
+            : "Additional Comments Required"
+        }
         onChange={handleChange}
       ></textarea>
+      <div className="errors" hidden={!errors.reasons && !errors.other}>
+        {errors.reasons || errors.other}
+      </div>
 
       <button type="submit">Submit</button>
     </form>

--- a/src/pages/Report.jsx
+++ b/src/pages/Report.jsx
@@ -1,0 +1,77 @@
+import React, { useState } from "react";
+import "./Report.css";
+import { useParams } from "react-router-dom";
+
+export default function Report() {
+  const [formData, setFormData] = useState({
+    reasons: {},
+    "additional-comments": "",
+  });
+  const params = useParams();
+  const reportOptions = [
+    "Wrong Tags",
+    "Hate Speech",
+    "Personal Information",
+    "Threats of Violence/Terrorism",
+    "Breaks TOS",
+    "Other",
+  ];
+
+  function handleChange(event) {
+    const { name, value, checked } = event.target;
+    if (name.startsWith("report-reason")) {
+      setFormData({
+        ...formData,
+        reasons: {
+          ...formData.reasons,
+          [value]: checked,
+        },
+      });
+    } else {
+      setFormData({
+        ...formData,
+        [name]: value,
+      });
+    }
+  }
+
+  function submitReport(event) {
+    event.preventDefault();
+    const reportData = {
+      echo_id: params.id,
+      additionalComments: formData["additional-comments"],
+      reasons: Object.keys(formData.reasons).filter(
+        (key) => formData.reasons[key] === true,
+      ),
+    };
+    console.log(reportData);
+  }
+
+  return (
+    <form className="report-container" onSubmit={submitReport}>
+      <h1 className="report-id">Echo ID: {params.id}</h1>
+      <ol className="report-list">
+        {reportOptions.map((option, index) => (
+          <li key={index}>
+            <input
+              type="checkbox"
+              name={`report-reason-${index}`}
+              value={option}
+              checked={formData.reasons[option] || false}
+              onChange={handleChange}
+            />
+            <label htmlFor={`report-reason-${index}`}>{option}</label>
+          </li>
+        ))}
+      </ol>
+      <textarea
+        name="additional-comments"
+        id="additional-comments"
+        placeholder="Additional Comments"
+        onChange={handleChange}
+      ></textarea>
+
+      <button type="submit">Submit</button>
+    </form>
+  );
+}

--- a/src/pages/Report.jsx
+++ b/src/pages/Report.jsx
@@ -53,9 +53,10 @@ export default function Report() {
       });
       return;
     }
+    // reporter_id should probably be taken from the JWT in the middleware to prevent unathorized reports
     const reportData = {
       echo_id: params.id,
-      additionalComments: formData["additional-comments"],
+      comments: formData["additional-comments"],
       reasons: Object.keys(formData.reasons).filter(
         (key) => formData.reasons[key] === true,
       ),

--- a/src/pages/Report.jsx
+++ b/src/pages/Report.jsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import "./Report.css";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 export default function Report() {
   // There might need to be a GET request here to validate the echo id even exists initially, but probably not a priority for now
@@ -10,6 +10,16 @@ export default function Report() {
   });
   const [errors, setErrors] = useState({ reasons: "" });
   const params = useParams();
+  const navigate = useNavigate();
+
+  // Validate that id is a number, if not navigate to 404
+  useEffect(() => {
+    if (isNaN(params.id)) {
+      navigate("/404");
+      return null;
+    }
+  }, []);
+
   const reportOptions = [
     "Wrong tags",
     "Hate speech",

--- a/src/pages/Report.jsx
+++ b/src/pages/Report.jsx
@@ -16,7 +16,6 @@ export default function Report() {
   useEffect(() => {
     if (isNaN(params.id)) {
       navigate("/404");
-      return null;
     }
   }, []);
 


### PR DESCRIPTION
The report page is navigated to by way of `browserUrl/report/:id`. The `:id` works the same as express, its already being sent to the page dynamically:
Proper Usage:
* ✅`<URL>/report/3` --> Displays the echo id given to it and displays it
Improper Usage:
* ❌`<URL>/report/lshdfjkl` --> Anything non numeric should send you to 404
* ❌`<URL>/report` --> No id should send you to 404

To make this work, I updated `/dist/index.html` by changing the `src=main.js` to `src=/main.js`. The route with the `:id` parameter was not working properly without it, but if it caused issues somewhere else we can revert it and find another solution.

Error handling should be working as expected:
* At least one selection is necessary for submission.
* Selecting the `Other` option will require additional comments, whether it is the only option selected or one of many.

Successful submission example, sends an object that looks like:

```JavaScript
{
      echo_id: 3,
      comments: "Not enough horses!",
      reasons: ["Other", "Threats of violence/Terrorism"]
}
```

